### PR TITLE
Do not use the fb-flo watcher, directly hook into onCompile

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,15 @@ function FbFloBrunch(config) {
     return;
   }
 
+  // Directly hook into fb-flo on compile if not using fb-flo's watcher
+  this.onCompile = this.config.disableWatcher ? function(generatedFiles) {
+    for (var idx = 0; idx < generatedFiles.length; ++idx) {
+      this._flo.onFileChange(
+        path.relative(this.config.publicPath, generatedFiles[idx].path)
+      );
+    }
+  } : undefined;
+
   this.resolver = this.resolver.bind(this);
   this.startServer();
 }
@@ -152,15 +161,6 @@ extend(FbFloBrunch.prototype, {
       this.resolver
     );
   },
-
-  // Directly hook into fb-flo on compile if not using fb-flo's watcher
-  onCompile: this.config.disableWatcher ? function(generatedFiles) {
-    for (var idx = 0; idx < generatedFiles.length; ++idx) {
-      this._flo.onFileChange(
-        path.relative(this.config.publicPath, generatedFiles[idx].path)
-      );
-    }
-  } : undefined,
 
   // Stops the fb-flo server when Brunch shuts down.
   teardown: function tearDownFbFlo() {

--- a/index.js
+++ b/index.js
@@ -149,6 +149,15 @@ extend(FbFloBrunch.prototype, {
     );
   },
 
+  // Directly hook into fb-flo on compile
+  onCompile: function(generatedFiles) {
+    for (var idx = 0; idx < generatedFiles.length; ++idx) {
+      this._flo.onFileChange(
+        path.relative(this.config.publicPath, generatedFiles[idx].path)
+      );
+    }
+  },
+
   // Stops the fb-flo server when Brunch shuts down.
   teardown: function tearDownFbFlo() {
     // If the plugin was disabled, we didn't start the server, so check.

--- a/index.js
+++ b/index.js
@@ -136,8 +136,7 @@ extend(FbFloBrunch.prototype, {
   // plugin is disabled.
   startServer: function startServer() {
     this._flo = flo(
-      // The path to watch (see `setOptions(…)`).
-      this.config.publicPath,
+      null, // do not watch, use onCompile only (triggers faster)
       // The config-provided fb-flo options + a generic watch glob
       // (all JS/CSS, at any depth) inside the watched path.
       extend(

--- a/index.js
+++ b/index.js
@@ -28,13 +28,15 @@ function FbFloBrunch(config) {
   }
 
   // Directly hook into fb-flo on compile if not using fb-flo's watcher
-  this.onCompile = this.config.disableWatcher ? function(generatedFiles) {
-    for (var idx = 0; idx < generatedFiles.length; ++idx) {
-      this._flo.onFileChange(
-        path.relative(this.config.publicPath, generatedFiles[idx].path)
-      );
-    }
-  } : undefined;
+  if (this.config.disableWatcher) {
+    this.onCompile = function onCompile(generatedFiles) {
+      for (var idx = 0; idx < generatedFiles.length; ++idx) {
+        this._flo.onFileChange(
+          path.relative(this.config.publicPath, generatedFiles[idx].path)
+        );
+      }
+    };
+  }
 
   this.resolver = this.resolver.bind(this);
   this.startServer();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "amp-extend": "^1.0.1",
     "amp-pick": "^1.0.0",
     "anymatch": "^1.1.0",
-    "fb-flo": "^0.4.0"
+    "fb-flo": "^0.5.0"
   },
   "devDependencies": {
     "chai": "^2.1.1",


### PR DESCRIPTION
I experimented with this plugin -- thanks a lot for providing it.
However using a secondary watcher leads to a significant lag between the moment when compilation finishes and the moment fb-flo's watcher notices the file change (at least on linux machines).

So I would deem hooking into onCompile a superior solution.
When fb-flo upstream accepted [my pull request to make starting a watcher optional](https://github.com/facebook/fb-flo/pull/102) this could be achieved with this PR.
