### PR TITLE
Fuzzy match resource names (e.g. containing a hash).

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ In the table below, the “fb-flo?” column states whether this is just an fb-f
 | `port`    | server | What port to listen to | 8888 |
 | `resolverMatch` | resolver (`match`) | *see fb-flo* | *see fb-flo* |
 | `resolverReload` | resolver (`reload`) | Extends fb-flo's boolean-only values with [anymatch sets](https://www.npmjs.com/package/anymatch), allowing for tremendous flexibility | `false` |
+| `fuzzyMatch` | resolver | Fuzzy match to cater for resources with hashes in URL | `false` |
 | `useFilePolling` | server | *see fb-flo* | *see fb-flo* |
 | `useWatchman` | server | *see fb-flo* | *see fb-flo* |
 | `verbose` | server | Whether to output everything on the wire… | `false` |

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ extend(FbFloBrunch.prototype, {
       if ('.' === dir) {
         dir = '';
       } else {
-        dir = path.joih(dir, '');
+        dir = path.join(dir, '');
       }
       options.match = new RegExp(dir + '.*' +
                       path.basename(filePath, ext) + '.*\\' + ext);

--- a/test/core.js
+++ b/test/core.js
@@ -248,6 +248,19 @@ describe('the plugin', function() {
         reload: true
       });
     });
+
+    it('should pass the proper regex if fuzzyMatch is set', function() {
+      var obj = new Plugin({
+        paths: { public: publicPath },
+        plugins: { fbFlo: { fuzzyMatch: true } }
+      });
+      var spy = sinon.spy();
+      var expectedRE = new RegExp('.*foo.*\\.js');
+      obj.resolver(fileName, spy);
+      spy.should.have.been.calledWithMatch({
+        match: expectedRE
+      });
+    });
   });
 
   function callWithConfig() {


### PR DESCRIPTION
More often than not somewhere in the build and/or delivery of resources a content hash is mixed into the resource's URL. It would be great if automatic "fuzzy" matching on such resources would be possible to avoid the need for a full reload cycle.

This PR implements that feature, updated documentation and a test case are included as well.
